### PR TITLE
updated master.bib to include xie2013ddrk

### DIFF
--- a/master.bib
+++ b/master.bib
@@ -18,3 +18,14 @@
   Owner                    = {steve},
   Timestamp                = {2016.02.12}
 }
+
+@Book{xie2013ddrk,
+  title = {Dynamic Documents with {R} and knitr},
+  author = {Yihui Xie},
+  publisher = {Chapman and Hall/CRC},
+  address = {Boca Raton, Florida},
+  year = {2015},
+  edition = {2nd},
+  note = {ISBN 978-1498716963},
+  url = {https://yihui.name/knitr/},
+}


### PR DESCRIPTION
This will permit the default article to compile using master.bib (as long as the templates are put in an acceptable folder)